### PR TITLE
Feature/#104 metrics

### DIFF
--- a/BookHub.API/BookHub.API.csproj
+++ b/BookHub.API/BookHub.API.csproj
@@ -19,11 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Npgsql" Version="8.0.5" />
@@ -41,6 +37,7 @@
   <ItemGroup>
     <ProjectReference Include="..\BookHub.Logic\BookHub.Logic.csproj" />
     <ProjectReference Include="..\BookHub.Storage\BookHub.Storage.csproj" />
+    <ProjectReference Include="..\Metrics\BookHub.Metrics.csproj" />
   </ItemGroup>
 
 </Project>

--- a/BookHub.API/Program.cs
+++ b/BookHub.API/Program.cs
@@ -27,6 +27,7 @@ builder.Services
     .AddAuth(builder.Configuration)
     .AddLogic(builder.Configuration)
     .AddPostgresStorage(builder.Environment, builder.Configuration)
+    .AddMetrics(builder.Configuration)
     .AddHttpClient<IYandexAuthService, YandexAuthService>();
 
 var app = builder.Build();

--- a/BookHub.API/Program.cs
+++ b/BookHub.API/Program.cs
@@ -1,6 +1,7 @@
 using BookHub.Abstractions.Logic.Services.Auth;
 using BookHub.API.Authentification;
 using BookHub.API.Registrations;
+using BookHub.Metrics;
 
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;

--- a/BookHub.API/Registrations/MetricsExtensions.cs
+++ b/BookHub.API/Registrations/MetricsExtensions.cs
@@ -1,0 +1,31 @@
+﻿using BookHub.Abstractions.Metrics;
+using BookHub.Metrics;
+using BookHub.Metrics.Configurations;
+using BookHub.Metrics.TargetFactory;
+
+using Microsoft.Extensions.Options;
+
+namespace BookHub.API.Registrations;
+
+static internal class MetricsExtensions
+{
+    public static IServiceCollection AddMetrics(
+        this IServiceCollection services,
+        IConfiguration configuration)
+        => services
+            .AddSingleton<IMetricsManager, MetricsManager>()
+            .AddSingleton<IMetricTargetFactory, MetricTargetFactory>()
+            .AddHostedService<KestrelMetricsBackgroundServer>()
+
+            .Configure<KestrelMetricServerConfiguration>(
+                configuration.GetSection(nameof(KestrelMetricServerConfiguration)))
+            .AddSingleton<
+                IValidateOptions<KestrelMetricServerConfiguration>,
+                KestrelMetricServerConfigurationValidator>()
+
+            .Configure<TargetAppSourceMetricsConfiguration>(
+                configuration.GetSection(nameof(TargetAppSourceMetricsConfiguration)))
+            .AddSingleton<
+                IValidateOptions<TargetAppSourceMetricsConfiguration>,
+                TargetAppSourceMetricsConfigurationValidator>();
+}

--- a/BookHub.API/Registrations/MetricsExtensions.cs
+++ b/BookHub.API/Registrations/MetricsExtensions.cs
@@ -3,6 +3,7 @@ using BookHub.Metrics;
 using BookHub.Metrics.Configurations;
 using BookHub.Metrics.TargetFactory;
 
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Options;
 
 namespace BookHub.API.Registrations;
@@ -13,6 +14,11 @@ static internal class MetricsExtensions
         this IServiceCollection services,
         IConfiguration configuration)
         => services
+            .AddScoped<IActionFilter, MetricsActionFilter>()
+
+            .AddControllers(opt => opt.Filters.Add<MetricsActionFilter>())
+            .Services
+
             .AddSingleton<IMetricsManager, MetricsManager>()
             .AddSingleton<IMetricTargetFactory, MetricTargetFactory>()
             .AddHostedService<KestrelMetricsBackgroundServer>()

--- a/BookHub.API/appsettings.json
+++ b/BookHub.API/appsettings.json
@@ -1,56 +1,65 @@
 {
-  "AuthJWTConfiguration": {
-    "Google": {
-      "Issuer": "google_issuer",
-      "Audience": "google_audience",
-      "ValidateIssuer": "true",
-      "ValidateAudience": "true",
-      "ValidateSignature": "false"
-    },
-    "Yandex": {
-      "Issuer": "yandex_issuer",
-      "Audience": "yandex_audience",
-      "ValidateIssuer": "true",
-      "ValidateAudience": "true",
-      "ValidateSignature": "false"
-    }
-  },
-
-
-  "TestConfig": {
-    "Content": "Default config content"
-  },
-
-  "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5432;Database=books_hub;Username=postgres;Password=admin;"
-  },
-
-  "AllowedHosts": "*",
-
-  "Serilog": {
-    "Using": [ "Serilog.Sinks.Console" ],
-    "MinimumLevel": {
-      "Default": "Debug",
-      "Override": {
-        "Microsoft": "Warning",
-        "System": "Warning",
-        "Microsoft.EntityFrameworkCore": "Information"
-      }
-    },
-    "WriteTo": [
-      {
-        "Name": "Console",
-        "Args": {
-          "projectID": "book-hub",
-          "labels": {
-            "project": "book-hub",
-            "service": "book-hub-api",
-            "type": "api"
-          },
-          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Scope:l} {Message:lj}{NewLine}{Exception}"
+    "AuthJWTConfiguration": {
+        "Google": {
+            "Issuer": "google_issuer",
+            "Audience": "google_audience",
+            "ValidateIssuer": "true",
+            "ValidateAudience": "true",
+            "ValidateSignature": "false"
+        },
+        "Yandex": {
+            "Issuer": "yandex_issuer",
+            "Audience": "yandex_audience",
+            "ValidateIssuer": "true",
+            "ValidateAudience": "true",
+            "ValidateSignature": "false"
         }
-      }
-    ],
-    "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId", "WithOneLinerExceptions" ]
-  }
+    },
+
+
+    "TestConfig": {
+        "Content": "Default config content"
+    },
+
+    "ConnectionStrings": {
+        "DefaultConnection": "Host=localhost;Port=5432;Database=books_hub;Username=postgres;Password=admin;"
+    },
+
+    "KestrelMetricServerConfiguration": {
+        "Host": "localhost",
+        "Port": 9000
+    },
+
+    "TargetAppSourceMetricsConfiguration": {
+        "AppSource": "BookHub.API"
+    },
+
+    "AllowedHosts": "*",
+
+    "Serilog": {
+        "Using": [ "Serilog.Sinks.Console" ],
+        "MinimumLevel": {
+            "Default": "Debug",
+            "Override": {
+                "Microsoft": "Warning",
+                "System": "Warning",
+                "Microsoft.EntityFrameworkCore": "Information"
+            }
+        },
+        "WriteTo": [
+            {
+                "Name": "Console",
+                "Args": {
+                    "projectID": "book-hub",
+                    "labels": {
+                        "project": "book-hub",
+                        "service": "book-hub-api",
+                        "type": "api"
+                    },
+                    "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Scope:l} {Message:lj}{NewLine}{Exception}"
+                }
+            }
+        ],
+        "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId", "WithOneLinerExceptions" ]
+    }
 }

--- a/BookHub.API/appsettings.json
+++ b/BookHub.API/appsettings.json
@@ -22,12 +22,12 @@
     },
 
     "ConnectionStrings": {
-        "DefaultConnection": "Host=localhost;Port=5432;Database=books_hub;Username=postgres;Password=root;"
+        "DefaultConnection": "Host=localhost;Port=5432;Database=books_hub;Username=postgres;Password=admin;"
     },
 
     "KestrelMetricServerConfiguration": {
         "Host": "localhost",
-        "Port": 9000
+        "Port": 9001
     },
 
     "TargetAppSourceMetricsConfiguration": {

--- a/BookHub.API/appsettings.json
+++ b/BookHub.API/appsettings.json
@@ -22,7 +22,7 @@
     },
 
     "ConnectionStrings": {
-        "DefaultConnection": "Host=localhost;Port=5432;Database=books_hub;Username=postgres;Password=admin;"
+        "DefaultConnection": "Host=localhost;Port=5432;Database=books_hub;Username=postgres;Password=root;"
     },
 
     "KestrelMetricServerConfiguration": {

--- a/BookHub.Abstractions/Metrics/IMetricsManager.cs
+++ b/BookHub.Abstractions/Metrics/IMetricsManager.cs
@@ -1,0 +1,11 @@
+﻿namespace BookHub.Abstractions.Metrics;
+
+/// <summary>
+/// Описывает менеджера для работы с метриками приложения.
+/// </summary>
+public interface IMetricsManager
+{
+    IDisposable? MeasureRequestsExecution(string apiMethodName);
+
+    void CountRequestsCalls(string apiMethodName);
+}

--- a/BookHub.sln
+++ b/BookHub.sln
@@ -28,6 +28,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BookHub.Metrics", "Metrics\BookHub.Metrics.csproj", "{8A351DDA-8B9E-44CF-82D0-A7651A7E182F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -74,6 +76,10 @@ Global
 		{55E2EF0E-5049-4468-9D4C-AA1E64EB2D6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{55E2EF0E-5049-4468-9D4C-AA1E64EB2D6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{55E2EF0E-5049-4468-9D4C-AA1E64EB2D6B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A351DDA-8B9E-44CF-82D0-A7651A7E182F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A351DDA-8B9E-44CF-82D0-A7651A7E182F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A351DDA-8B9E-44CF-82D0-A7651A7E182F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A351DDA-8B9E-44CF-82D0-A7651A7E182F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Metrics/ActivityToMetricsInstrumentation.cs
+++ b/Metrics/ActivityToMetricsInstrumentation.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace BookHub.Metrics;
+
+/// <summary>
+/// Инструментация для работы с метриками.
+/// </summary>
+public sealed class ActivityToMetricsInstrumentation : IDisposable
+{
+    public ActivityToMetricsInstrumentation(
+        string target)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(target);
+
+        _meter = new Meter(target);
+
+        _listener = new ActivityListener
+        {
+            Sample =
+            (ref ActivityCreationOptions<ActivityContext> _)
+                => ActivitySamplingResult.PropagationData,
+
+            ShouldListenTo = (source) =>
+                source.Name.Equals(target, StringComparison.Ordinal),
+
+            ActivityStopped = (activity) =>
+            {
+                var histogram = _histogramCache.GetOrAdd(
+                    activity.DisplayName,
+                    (name) => _meter.CreateHistogram<double>(name, "ms"));
+
+                histogram.Record(
+                    activity.Duration.TotalMilliseconds,
+                    activity.TagObjects.ToArray());
+            }
+        };
+
+        ActivitySource.AddActivityListener(_listener);
+    }
+
+    public void Dispose()
+    {
+        if (!_disposed)
+        {
+            _meter.Dispose();
+            _listener.Dispose();
+
+            _disposed = true;
+        }
+    }
+
+    private readonly ConcurrentDictionary<string, Histogram<double>> _histogramCache = new();
+    private readonly Meter _meter;
+    private readonly ActivityListener _listener;
+    private bool _disposed;
+}

--- a/Metrics/BookHub.Metrics.csproj
+++ b/Metrics/BookHub.Metrics.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />
+	<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.4.0-rc.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BookHub.Abstractions\BookHub.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Metrics/Configurations/KestrelMetricServerConfiguration.cs
+++ b/Metrics/Configurations/KestrelMetricServerConfiguration.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace BookHub.Metrics.Configurations;
+
+/// <summary>
+/// Конфигурация сервиса метрик Kestrel.
+/// </summary>
+public sealed class KestrelMetricServerConfiguration
+{
+    [Required(ErrorMessage = "Can't be null, empty or has only whitespaces.")]
+    public required string Host { get; init; }
+
+    public required int Port { get; init; }
+}

--- a/Metrics/Configurations/KestrelMetricServerConfigurationValidator.cs
+++ b/Metrics/Configurations/KestrelMetricServerConfigurationValidator.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.Options;
+
+namespace BookHub.Metrics.Configurations;
+
+public sealed class KestrelMetricServerConfigurationValidator :
+    IValidateOptions<KestrelMetricServerConfiguration>
+{
+    public ValidateOptionsResult Validate(
+        string? name, 
+        KestrelMetricServerConfiguration options)
+    {
+        if (string.IsNullOrWhiteSpace(options.Host))
+        {
+            return ValidateOptionsResult.Fail(
+                "Host can't be null, empty or has only whitespaces.");
+        }
+
+        if (options.Port < 1)
+        {
+            return ValidateOptionsResult.Fail("Port should be greater than zero.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/Metrics/Configurations/TargetAppSourceMetricsConfiguration.cs
+++ b/Metrics/Configurations/TargetAppSourceMetricsConfiguration.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace BookHub.Metrics.Configurations;
+
+/// <summary>
+/// Конфигурация указания таргета источника приложения.
+/// </summary>
+public sealed class TargetAppSourceMetricsConfiguration
+{
+    [Required(ErrorMessage = "Can't be null, empty or has only whitespaces.")]
+    public required string AppSource { get; init; }
+}

--- a/Metrics/Configurations/TargetAppSourceMetricsConfigurationValidator.cs
+++ b/Metrics/Configurations/TargetAppSourceMetricsConfigurationValidator.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Extensions.Options;
+
+namespace BookHub.Metrics.Configurations;
+
+[OptionsValidator]
+public sealed partial class TargetAppSourceMetricsConfigurationValidator :
+    IValidateOptions<TargetAppSourceMetricsConfiguration>
+{
+}

--- a/Metrics/KestrelMetricsBackgroundServer.cs
+++ b/Metrics/KestrelMetricsBackgroundServer.cs
@@ -1,0 +1,69 @@
+﻿using BookHub.Metrics.Configurations;
+using BookHub.Metrics.TargetFactory;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using OpenTelemetry.Metrics;
+
+namespace BookHub.Metrics;
+
+/// <summary>
+/// Сервер Kestrel, являющийся сайдкаром основного приложения 
+/// для сбора и экспорта метрик в Prometheus.
+/// </summary>
+public sealed class KestrelMetricsBackgroundServer : BackgroundService
+{
+    public KestrelMetricsBackgroundServer(
+        IOptions<KestrelMetricServerConfiguration> options,
+        ILogger<KestrelMetricsBackgroundServer> logger,
+        IMetricTargetFactory metricTargetFactory)
+    {
+        ArgumentNullException.ThrowIfNull(metricTargetFactory);
+        _targets = metricTargetFactory.CreateTargets();
+
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        var config = options?.Value 
+            ?? throw new ArgumentNullException(nameof(options));
+
+        _hostAddress = $"https://{config.Host}:{config.Port}";
+
+        _logger.LogInformation(
+            "Kestrel server can be accessed by host '{Host}'",
+            _hostAddress);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken) =>
+        await new WebHostBuilder()
+            .UseKestrel()
+            .ConfigureServices(
+                services => services.AddOpenTelemetry()
+                    .WithMetrics(providerBuilder =>
+                    {
+                        _ = providerBuilder.AddPrometheusExporter();
+                        _ = providerBuilder.AddRuntimeInstrumentation();
+
+                        foreach (var target in _targets)
+                        {
+                            _ = providerBuilder.AddMeter(target);
+
+                            _ = providerBuilder.AddInstrumentation(() =>
+                                new ActivityToMetricsInstrumentation(target));
+                        }
+                    }))
+            .Configure(
+                app => app.UseOpenTelemetryPrometheusScrapingEndpoint())
+            .UseUrls(_hostAddress)
+            .Build()
+            .RunAsync(stoppingToken);
+
+    private readonly string _hostAddress;
+    private readonly IEnumerable<string> _targets;
+
+    private readonly ILogger<KestrelMetricsBackgroundServer> _logger;
+}

--- a/Metrics/MetricsActionFilter.cs
+++ b/Metrics/MetricsActionFilter.cs
@@ -4,9 +4,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace BookHub.Metrics;
 
-public sealed class MetricsActionFilter : 
-    IActionFilter,
-    IDisposable
+public sealed class MetricsActionFilter : IActionFilter
 {
     public MetricsActionFilter(
         IMetricsManager metricsManager)
@@ -17,30 +15,22 @@ public sealed class MetricsActionFilter :
 
     public void OnActionExecuting(ActionExecutingContext context)
     {
-        var actionName = 
+        _actionName = 
             $"{context.ActionDescriptor.RouteValues["controller"]}" +
             $".{context.ActionDescriptor.RouteValues["action"]}";
 
-        _metricsManager.CountRequestsCalls(actionName);
-
-        _metricJob = _metricsManager.MeasureRequestsExecution(actionName);
+        _metricJob = _metricsManager.MeasureRequestsExecution(_actionName);
     }
 
     public void OnActionExecuted(ActionExecutedContext context)
     {
+        _metricsManager.CountRequestsCalls(_actionName!);
+
+        _metricJob!.Dispose();
     }
 
-    public void Dispose()
-    {
-        if (!_disposed)
-        {
-            _metricJob!.Dispose();
+    private string? _actionName;
 
-            _disposed = true;
-        }
-    }
-
-    private bool _disposed;
     private IDisposable? _metricJob;
 
     private readonly IMetricsManager _metricsManager;

--- a/Metrics/MetricsActionFilter.cs
+++ b/Metrics/MetricsActionFilter.cs
@@ -1,0 +1,43 @@
+﻿using BookHub.Abstractions.Metrics;
+
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Logging;
+
+namespace BookHub.Metrics;
+
+public sealed class MetricsActionFilter : IActionFilter
+{
+    public MetricsActionFilter(
+        IMetricsManager metricsManager,
+        ILogger<MetricsActionFilter> logger)
+    {
+        _metricsManager = metricsManager 
+            ?? throw new ArgumentNullException(nameof(metricsManager));
+        _logger = logger
+            ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public void OnActionExecuting(ActionExecutingContext context)
+    {
+        _actionName = 
+            $"{context.ActionDescriptor.RouteValues["controller"]}" +
+            $".{context.ActionDescriptor.RouteValues["action"]}";
+
+        using (_metricsManager.MeasureRequestsExecution(_actionName))
+        {
+            // some code
+        }
+    }
+
+    public void OnActionExecuted(ActionExecutedContext context)
+    {
+        _metricsManager.CountRequestsCalls(_actionName);
+
+        _logger.LogInformation("Action '{ActionName}' was completed", _actionName);
+    }
+
+    private string _actionName;
+
+    private readonly IMetricsManager _metricsManager;
+    private readonly ILogger<MetricsActionFilter> _logger;
+}

--- a/Metrics/MetricsActionFilter.cs
+++ b/Metrics/MetricsActionFilter.cs
@@ -23,24 +23,36 @@ public sealed class MetricsActionFilter :
 
         _metricsManager.CountRequestsCalls(actionName);
 
+        ObjectDisposedException.ThrowIf(_isMetricJobDisposed, this);
+
         _metricJob = _metricsManager.MeasureRequestsExecution(actionName);
     }
 
     public void OnActionExecuted(ActionExecutedContext context)
     {
+        ObjectDisposedException.ThrowIf(_isMetricJobDisposed, this);
+
+        _metricJob!.Dispose();
+
+        _isMetricJobDisposed = true;
     }
 
     public void Dispose()
     {
         if (!_disposed)
         {
-            _metricJob!.Dispose();
+            if (!_isMetricJobDisposed)
+            {
+                _metricJob!.Dispose();
+            }
 
             _disposed = true;
         }
     }
 
     private bool _disposed;
+
+    private bool _isMetricJobDisposed;
     private IDisposable? _metricJob;
 
     private readonly IMetricsManager _metricsManager;

--- a/Metrics/MetricsManager.cs
+++ b/Metrics/MetricsManager.cs
@@ -1,0 +1,52 @@
+﻿using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+using BookHub.Abstractions.Metrics;
+using BookHub.Metrics.Configurations;
+
+using Microsoft.Extensions.Options;
+
+namespace BookHub.Metrics;
+
+public sealed class MetricsManager : IMetricsManager
+{
+    public MetricsManager(
+        IOptions<TargetAppSourceMetricsConfiguration> options)
+    {
+        var appSource = options?.Value.AppSource
+            ?? throw new ArgumentNullException(nameof(options));
+
+        _meter = new Meter(appSource);
+        _activitySource = new ActivitySource(appSource);
+        _counter = _meter.CreateCounter<long>(ACTIVITY_NAME_COUNTING);
+    }
+
+    public IDisposable? MeasureRequestsExecution(string apiMethodName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(apiMethodName);
+
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        return _activitySource
+            .StartActivity(ACTIVITY_NAME_MEASURING)
+            ?.SetTag(TAG_KEY, apiMethodName);
+    }
+
+    public void CountRequestsCalls(string apiMethodName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(apiMethodName);
+
+        _counter.Add(1, new KeyValuePair<string, object?>(TAG_KEY, apiMethodName));
+    }
+
+    private readonly Meter _meter;
+    private readonly ActivitySource _activitySource;
+    private bool _disposed;
+
+    private readonly Counter<long> _counter;
+
+    private const string ACTIVITY_NAME_MEASURING = "execute_request";
+    private const string ACTIVITY_NAME_COUNTING = "request_calls_count";
+
+    private const string TAG_KEY = "api_method_name";
+}

--- a/Metrics/TargetFactory/IMetricTargetFactory.cs
+++ b/Metrics/TargetFactory/IMetricTargetFactory.cs
@@ -1,0 +1,9 @@
+﻿namespace BookHub.Metrics.TargetFactory;
+
+/// <summary>
+/// Описывает фабрику для кастомных таргетов.
+/// </summary>
+public interface IMetricTargetFactory
+{
+    IEnumerable<string> CreateTargets();
+}

--- a/Metrics/TargetFactory/MetricTargetFactory.cs
+++ b/Metrics/TargetFactory/MetricTargetFactory.cs
@@ -1,0 +1,26 @@
+﻿
+using BookHub.Metrics.Configurations;
+
+using Microsoft.Extensions.Options;
+
+namespace BookHub.Metrics.TargetFactory;
+
+/// <summary>
+/// Представляет фабрику для кастомных таргетов.
+/// </summary>
+public sealed class MetricTargetFactory :
+    IMetricTargetFactory
+{
+    public MetricTargetFactory(
+        IOptions<TargetAppSourceMetricsConfiguration> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        _targets = [options.Value.AppSource];
+    }
+
+
+    public IEnumerable<string> CreateTargets() => _targets;
+
+    private readonly IReadOnlyCollection<string> _targets;
+}


### PR DESCRIPTION
resolved #104 

добавил open telemetry метрики, которые будут собираться для каждого исполняемого API метода (будет считаться время запроса - а также кол-во исполнений каждого эндпоинт метода)

Экспортировать их можно из Prometheus по адресу: https://adress:9001/metrics

В конфиге ввел KestrelMetricServerConfiguration - там надо определить хост на котором будут метрики и порт

![image](https://github.com/user-attachments/assets/eeed69b6-13a1-4e72-af16-6cf40f2caf91)

